### PR TITLE
Add impersonateAccount & stopImpersonatingAccount

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
 
     steps:

--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ to participate in the EVM network space.
 |                 `forkBlock` |     ✅      |        ✅         |
 | `setNextBlockBaseFeePerGas` |     ✅      |        ✅         |
 |              `setStorageAt` |     ✅      |        ✅         |
+|        `impersonateAccount` |     ✅      |        ✅         |
+|  `stopImpersonatingAccount` |     ✅      |        ✅         |
 
 ## Goals
 
 Have a neat and simple interface to the local hardhat or anvil node from your Java/Kotlin/Scala code. As simple as:
 
 ```kotlin
-  // start node in fork mode
+  // start local node in fork mode
   val node = HardhatNode.fork(config)
   val node = AnvilNode.fork(config)
 
@@ -43,6 +45,10 @@ Have a neat and simple interface to the local hardhat or anvil node from your Ja
   web3.forkBlock(blockNumber)
   web3.mine(42)
   web3.setBalance(MY_WALLET, UNICORN_DOLLARS)
+
+  web3.impersonateAccount(HONEYPOT)
+  . . .
+  web3.stopImpersonatingAccount(HONEYPOT)
 ```
 
 Seriously, Java devs deserve it.

--- a/core/src/main/kotlin/vc/rux/pokefork/ILocalNode.kt
+++ b/core/src/main/kotlin/vc/rux/pokefork/ILocalNode.kt
@@ -32,4 +32,11 @@ interface ILocalNode {
      * @throws IllegalArgumentException if offset is greater than 32 bytes or negative
      */
     fun setStorageAt(destination: String, offset: BigInteger, value: BigInteger)
+
+    /**
+     * Impersonates the specified EOA
+     * @param address EOA address to impersonate
+     */
+    fun impersonateAccount(address: String)
+    fun stopImpersonatingAccount(address: String)
 }

--- a/web3j/src/main/kotlin/vc/rux/pokefork/web3j/LocalWeb3jNode.kt
+++ b/web3j/src/main/kotlin/vc/rux/pokefork/web3j/LocalWeb3jNode.kt
@@ -73,6 +73,16 @@ class LocalWeb3jNode(
         )
     }
 
+    override fun impersonateAccount(address: String) {
+        log.info("impersonateAccount: {}", address)
+        sendRpcCallAndCheckResponse("hardhat_impersonateAccount", listOf(address))
+    }
+
+    override fun stopImpersonatingAccount(address: String) {
+        log.info("stopImpersonatingAccount: {}", address)
+        sendRpcCallAndCheckResponse("hardhat_stopImpersonatingAccount", listOf(address))
+    }
+
     /**
      * Helper method; reduces boilerplate
      */


### PR DESCRIPTION
Allow impersonate address by utilising `hardhat_impersonateAccount` RPC method

Example use:

```kotlin
val sendAllEthTx = run {
    val nonce = web3.ethGetTransactionCount(VITALIK_WALLET, LATEST).send().transactionCount
    val ethBalance = web3.ethGetBalance(VITALIK_WALLET, LATEST).send().balance
    val gasPrice = web3.ethGasPrice().send().gasPrice
    return Transaction.createEtherTransaction(
        VITALIK_WALLET, nonce, gasPrice, 21_000.toBigInteger(), ZERO_ADDRESS, ethBalance - gasPrice * 21_000.toBigInteger()
    )
}
web3.impersonateAccount(VITALIK_WALLET)
web3.ethSendTransaction(sendAllEthTx).send().throwIfErrored()
```


Closes #7